### PR TITLE
Add flexible error handling in policy worker, configurable through the PolicyContract

### DIFF
--- a/src/Aggregates.EventStoreDB/Aggregates.EventStoreDB.csproj
+++ b/src/Aggregates.EventStoreDB/Aggregates.EventStoreDB.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.34.2</Version>
+    <Version>0.35.0</Version>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Aggregates.EventStoreDB/Workers/PolicyWorker.cs
+++ b/src/Aggregates.EventStoreDB/Workers/PolicyWorker.cs
@@ -258,7 +258,7 @@ class ContinueUntilMaxFailureRateHandler<TCommand, TState, TEvent>(IServiceScope
         try {
             await asyncHandleFunc(command);
         } catch (Exception ex) {
-            var rate = (double)_errors / batchSize;
+            var rate = (double)++_errors / batchSize;
 
             if (rate > maxFailureRate + double.Epsilon)
                 throw;

--- a/src/Aggregates.EventStoreDB/Workers/PolicyWorker.cs
+++ b/src/Aggregates.EventStoreDB/Workers/PolicyWorker.cs
@@ -9,7 +9,6 @@ using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Aggregates.Configuration;
 using Aggregates.Policies;
-using Aggregates.Sagas;
 
 namespace Aggregates.EventStoreDB.Workers;
 
@@ -42,9 +41,11 @@ class PolicyWorker<TPolicy, TPolicyEvent, TCommand, TState, TEvent>(IServiceScop
         TPolicy owner,
         CancellationToken stoppingToken) {
 
-        var (subscriptionGroupName, @delegate, skipPosition) = await BootstrapAsync(owner, listToAllAsync, createToAllAsync, deleteToAllAsync, options, stoppingToken);
+        var (subscriptionGroupName, @delegate, policyHandler, skipPosition) = await BootstrapAsync(owner, ServiceScopeFactory, logger, listToAllAsync, createToAllAsync, deleteToAllAsync, options, stoppingToken);
         if (owner is null || @delegate is null)
             return;
+
+        policyHandler ??= new FailFastHandler<TCommand, TState, TEvent>(ServiceScopeFactory);
 
         // now connect the subscription and start updating the projection state
         await Task.Run(async () => {
@@ -63,10 +64,11 @@ class PolicyWorker<TPolicy, TPolicyEvent, TCommand, TState, TEvent>(IServiceScop
                                         metadataScope.Add(pair);
                                     }
 
-                                    await foreach (var command in @delegate((TPolicyEvent)deserializer.Deserialize(@event.ResolvedEvent), metadata, stoppingToken)) {
-                                        using var scope = ServiceScopeFactory.CreateScope();
-                                        var commandHandler = scope.ServiceProvider.GetRequiredService<ICommandHandler<TCommand, TState, TEvent>>();
-                                        await commandHandler.HandleAsync(command);
+                                    var batch = await @delegate((TPolicyEvent)deserializer.Deserialize(@event.ResolvedEvent), metadata, stoppingToken).ToArrayAsync(cancellationToken: stoppingToken);
+
+                                    policyHandler.Reset();
+                                    foreach (var command in batch) {
+                                        await policyHandler.HandleAsync(@event, subscriptionGroupName, command, batch.Length);
                                     }
 
                                     // notify EventStoreDB that we're done
@@ -74,7 +76,7 @@ class PolicyWorker<TPolicy, TPolicyEvent, TCommand, TState, TEvent>(IServiceScop
                                 }
                                 catch (Exception ex) {
                                     logger.LogError(ex, "Exception occurred during handling of {eventType} @ {position} in subscription {subscriptionGroupName}.", @event.ResolvedEvent.Event.EventType, @event.ResolvedEvent.Event.Position, subscriptionGroupName);
-                                        await subscription.Nack(
+                                    await subscription.Nack(
                                         @event.RetryCount < 5
                                             ? PersistentSubscriptionNakEventAction.Retry
                                             : PersistentSubscriptionNakEventAction.Park, ex.Message,
@@ -105,12 +107,12 @@ class PolicyWorker<TPolicy, TPolicyEvent, TCommand, TState, TEvent>(IServiceScop
         await stoppingToken;
     }
 
-    static async Task<(string? subscriptionGroupName, PolicyAsyncDelegate<TPolicyEvent, TCommand, TState, TEvent>? @delegate, IPosition? skipPosition)> BootstrapAsync(TPolicy owner, ListToAllAsyncDelegate listToAllAsync, CreateToAllAsyncDelegate createToAllAsync, DeleteToAllAsyncDelegate deleteToAllAsync, AggregatesOptions options, CancellationToken cancellationToken) {
+    static async Task<(string? subscriptionGroupName, PolicyAsyncDelegate<TPolicyEvent, TCommand, TState, TEvent>? @delegate, PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent>? policyHandler, IPosition? skipPosition)> BootstrapAsync(TPolicy owner, IServiceScopeFactory serviceScopeFactory, ILogger logger, ListToAllAsyncDelegate listToAllAsync, CreateToAllAsyncDelegate createToAllAsync, DeleteToAllAsyncDelegate deleteToAllAsync, AggregatesOptions options, CancellationToken cancellationToken) {
         var ownerType = owner!.GetType();
         if (ownerType.GetCustomAttribute<PolicyContractAttribute>() is not { } policyContract)
-            return (null, null, null);
+            return (null, null, null, null);
 
-        // find saga delegate
+        // find policy delegate
         var @delegate = (
                 from method in ownerType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
                 where method.IsDelegate<PolicyAsyncDelegate<TPolicyEvent, TCommand, TState, TEvent>>(owner)
@@ -122,11 +124,19 @@ class PolicyWorker<TPolicy, TPolicyEvent, TCommand, TState, TEvent>(IServiceScop
                 select new PolicyAsyncDelegate<TPolicyEvent, TCommand, TState, TEvent>((@event, metadata, _) => dlgt(@event, metadata).ToAsyncEnumerable())
             ).SingleOrDefault();
         if (@delegate is null)
-            return (null, null, null);
+            return (null, null, null, null);
+
+        PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent> policyHandler = policyContract.ErrorHandlingMode switch {
+            PolicyErrorHandlingMode.FailFast => new FailFastHandler<TCommand, TState, TEvent>(serviceScopeFactory),
+            PolicyErrorHandlingMode.ContinueOnError => new ContinueOnErrorHandler<TCommand, TState, TEvent>(serviceScopeFactory, logger),
+            PolicyErrorHandlingMode.ContinueUntilMaxErrors => new ContinueUntilMaxErrorsHandler<TCommand, TState, TEvent>(serviceScopeFactory, logger, policyContract.MaxErrors),
+            PolicyErrorHandlingMode.ContinueUntilMaxFailureRate => new ContinueUntilMaxFailureRateHandler<TCommand, TState, TEvent>(serviceScopeFactory, logger, policyContract.MaxErrorRate),
+            _ => throw new ArgumentOutOfRangeException()
+        };
 
         // find subscription and create it if it doesn't exist
         var subscription = (await listToAllAsync(cancellationToken: cancellationToken)).FirstOrDefault(info => info.GroupName == policyContract.ToString());
-        if (subscription != null) return (subscription.GroupName, @delegate, null);
+        if (subscription != null) return (subscription.GroupName, @delegate, policyHandler, null);
 
         // find applicable event types by tentatively applying them to the state
         var eventTypes = (
@@ -160,6 +170,108 @@ class PolicyWorker<TPolicy, TPolicyEvent, TCommand, TState, TEvent>(IServiceScop
         // now create the new subscription
         await createToAllAsync(policyContract.ToString(), EventTypeFilter.RegularExpression($"^(?:{filter})$"), new PersistentSubscriptionSettings(startFrom: position), cancellationToken: cancellationToken);
 
-        return (policyContract.ToString(), @delegate, skipPosition);
+        return (policyContract.ToString(), @delegate, policyHandler, skipPosition);
+    }
+}
+
+abstract class PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent>(IServiceScopeFactory serviceScopeFactory)
+    where TState : IState<TState, TEvent>
+    where TCommand : ICommand<TState, TEvent> {
+    public abstract void Reset();
+
+    public async ValueTask HandleAsync(PersistentSubscriptionMessage.Event @event, string? subscriptionGroupName, TCommand command, int batchSize) {
+        using var scope = serviceScopeFactory.CreateScope();
+        var commandHandler = scope.ServiceProvider.GetRequiredService<ICommandHandler<TCommand, TState, TEvent>>();
+        await HandleCoreAsync(@event, subscriptionGroupName, command, commandHandler.HandleAsync, batchSize);
+    }
+
+    protected abstract ValueTask HandleCoreAsync(PersistentSubscriptionMessage.Event @event, string? subscriptionGroupName, TCommand command, Func<TCommand, ValueTask> asyncHandleFunc, int batchSize);
+}
+
+class FailFastHandler<TCommand, TState, TEvent>(IServiceScopeFactory serviceScopeFactory) : PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent>(serviceScopeFactory)
+    where TState : IState<TState, TEvent>
+    where TCommand : ICommand<TState, TEvent> {
+    public override void Reset() { }
+
+    protected override ValueTask HandleCoreAsync(PersistentSubscriptionMessage.Event @event, string? subscriptionGroupName, TCommand command, Func<TCommand, ValueTask> asyncHandleFunc, int batchSize) => asyncHandleFunc(command);
+}
+
+class ContinueOnErrorHandler<TCommand, TState, TEvent>(IServiceScopeFactory serviceScopeFactory, ILogger? logger) : PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent>(serviceScopeFactory)
+    where TState : IState<TState, TEvent>
+    where TCommand : ICommand<TState, TEvent> {
+    public override void Reset() { }
+
+    protected override async ValueTask HandleCoreAsync(PersistentSubscriptionMessage.Event @event, string? subscriptionGroupName, TCommand command, Func<TCommand, ValueTask> asyncHandleFunc, int batchSize) {
+        try {
+            await asyncHandleFunc(command);
+        } catch (Exception ex) {
+            logger?.LogError(
+                ex, 
+                "Exception occurred during handling of command {commandType} ({eventType} @ {position} in subscription {subscriptionGroupName}) but the policy is configured to continue on errors.", 
+                typeof(TCommand),
+                @event.ResolvedEvent.Event.EventType, 
+                @event.ResolvedEvent.Event.Position, subscriptionGroupName
+            );
+        }
+    }
+}
+
+class ContinueUntilMaxErrorsHandler<TCommand, TState, TEvent>(IServiceScopeFactory serviceScopeFactory, ILogger? logger, int maxErrors) : PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent>(serviceScopeFactory)
+    where TState : IState<TState, TEvent>
+    where TCommand : ICommand<TState, TEvent> {
+    int _errors;
+
+    public override void Reset() {
+        _errors = 0;
+    }
+
+    protected override async ValueTask HandleCoreAsync(PersistentSubscriptionMessage.Event @event, string? subscriptionGroupName, TCommand command, Func<TCommand, ValueTask> asyncHandleFunc, int batchSize) {
+        try {
+            await asyncHandleFunc(command);
+        } catch (Exception ex) {
+            if (++_errors > maxErrors)
+                throw;
+
+            logger?.LogError(
+                ex,
+                "Exception occurred during handling of command {commandType} ({eventType} @ {position} in subscription {subscriptionGroupName}) but the policy is configured to tolerate {maxErrors} errors (currently at {errors} errors for this event)",
+                typeof(TCommand),
+                @event.ResolvedEvent.Event.EventType,
+                @event.ResolvedEvent.Event.Position, subscriptionGroupName,
+                maxErrors,
+                _errors
+            );
+        }
+    }
+}
+
+class ContinueUntilMaxFailureRateHandler<TCommand, TState, TEvent>(IServiceScopeFactory serviceScopeFactory, ILogger? logger, double maxFailureRate) : PolicyErrorModeAwareCommandHandler<TCommand, TState, TEvent>(serviceScopeFactory)
+    where TState : IState<TState, TEvent>
+    where TCommand : ICommand<TState, TEvent> {
+    int _errors;
+
+    public override void Reset() {
+        _errors = 0;
+    }
+
+    protected override async ValueTask HandleCoreAsync(PersistentSubscriptionMessage.Event @event, string? subscriptionGroupName, TCommand command, Func<TCommand, ValueTask> asyncHandleFunc, int batchSize) {
+        try {
+            await asyncHandleFunc(command);
+        } catch (Exception ex) {
+            var rate = (double)_errors / batchSize;
+
+            if (rate > maxFailureRate + double.Epsilon)
+                throw;
+
+            logger?.LogError(
+                ex,
+                "Exception occurred during handling of command {commandType} ({eventType} @ {position} in subscription {subscriptionGroupName}) but the policy is configured to tolerate {maxErrors:P0} errors (currently at {errors:P0} errors for this event)",
+                typeof(TCommand),
+                @event.ResolvedEvent.Event.EventType,
+                @event.ResolvedEvent.Event.Position, subscriptionGroupName,
+                maxFailureRate,
+                _errors
+            );
+        }
     }
 }

--- a/src/Aggregates/Policies/PolicyContractAttribute.cs
+++ b/src/Aggregates/Policies/PolicyContractAttribute.cs
@@ -7,8 +7,19 @@
 /// <param name="version">The version of the policy. You should only ever have one version for every <paramref name="name"/> in your codebase.</param>
 /// <param name="namespace">Optional. A namespace to prepend to the name of your policy.</param>
 /// <param name="continueFrom">Optional. Specifies the name of a previous version of the policy to continue projecting from.</param>
+/// <param name="errorHandlingMode">Optional. Defines how the policy should behave when command handling errors occur. Defaults to <see cref="PolicyErrorHandlingMode.FailFast"/>.</param>
+/// <param name="maxErrors">Optional. Defines the maximum number of failures to tolerate before failing an event, in case the <paramref name="errorHandlingMode"/> is <see cref="PolicyErrorHandlingMode.ContinueUntilMaxErrors"/>. Defaults to 1.</param>
+/// <param name="maxErrorRate">Optional. Defines the maximum percentage of failures to tolerate before failing an event, in case the <paramref name="errorHandlingMode"/> is <see cref="PolicyErrorHandlingMode.ContinueUntilMaxFailureRate"/>. Defaults to 0.1 (10%).</param>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
-public class PolicyContractAttribute(string name, int version = 1, string? @namespace = null, string? continueFrom = null) : Attribute {
+public class PolicyContractAttribute(
+    string name, 
+    int version = 1, 
+    string? @namespace = null, 
+    string? continueFrom = null, 
+    PolicyErrorHandlingMode errorHandlingMode = PolicyErrorHandlingMode.FailFast,
+    int? maxErrors = 1,
+    double? maxErrorRate = .1
+) : Attribute {
     /// <summary>
     /// Returns the fully qualified name of the preceding policy contract, if any.
     /// </summary>
@@ -17,8 +28,61 @@ public class PolicyContractAttribute(string name, int version = 1, string? @name
         : null);
 
     /// <summary>
+    /// Defines how the policy should behave when command handling errors occur.
+    /// </summary>
+    public PolicyErrorHandlingMode ErrorHandlingMode => errorHandlingMode;
+
+    /// <summary>
+    /// Defines the maximum number of failures to tolerate before failing an event, in case the <see cref="ErrorHandlingMode"/> is <see cref="PolicyErrorHandlingMode.ContinueUntilMaxErrors"/>.
+    /// </summary>
+    public int MaxErrors => maxErrors ?? 1;
+
+    /// <summary>
+    /// Defines the maximum percentage of failures to tolerate before failing an event, in case the <see cref="ErrorHandlingMode"/> is <see cref="PolicyErrorHandlingMode.ContinueUntilMaxFailureRate"/>.
+    /// </summary>
+    public double MaxErrorRate => maxErrorRate ?? .1;
+
+    /// <summary>
     /// Returns the policy contract name.
     /// </summary>
     /// <returns>A <see cref="string"/>.</returns>
     public override string ToString() => $"{(!string.IsNullOrWhiteSpace(@namespace) ? $"{@namespace}." : string.Empty)}{name}@v{version}";
+}
+
+/// <summary>
+/// Defines how a policy should behave when command handling errors occur.
+/// </summary>
+public enum PolicyErrorHandlingMode {
+    /// <summary>
+    /// Stops processing any further commands when one command fails.
+    /// </summary>
+    /// <remarks>
+    /// This behaviour only applies to handling multiple commands in response to a single event. Failure does NOT affect the handling of commands for subsequent events.
+    /// </remarks>
+    FailFast,
+
+    /// <summary>
+    /// Continues processing remaining commands even if one fails.
+    /// </summary>
+    /// <remarks>
+    /// This mode causes the policy to ignore command handling errors and proceed with the next command. As a result, handling of a single event will never fail due to command errors. 
+    /// To introduce fault tolerance with thresholds, use <see cref="ContinueUntilMaxErrors"/> or <see cref="ContinueUntilMaxFailureRate"/> instead, and configure the threshold in the policy contract.
+    /// </remarks>
+    ContinueOnError,
+
+    /// <summary>
+    /// Continues processing further commands when failures occur, until a fixed maximum number of errors is reached.
+    /// </summary>
+    /// <remarks>
+    /// The number of command failures is counted per event. Once the configured maximum number of failures is reached, handling of the event itself fails.
+    /// </remarks>
+    ContinueUntilMaxErrors,
+
+    /// <summary>
+    /// Continues processing further commands when failures occur, until a maximum failure rate (percentage of the whole batch) is reached.
+    /// </summary>
+    /// <remarks>
+    /// The number of failed commands is tracked relative to the total number of commands for an event. Once the configured failure rate is exceeded, handling of the event itself fails.
+    /// </remarks>
+    ContinueUntilMaxFailureRate
 }


### PR DESCRIPTION
`PolicyContractAttribute` now provides a way to configure command error handling behaviour by means of the `errorHandlingMode` constructor argument:

* FailFast: no errors are tolerable. Whenever a command throws an exception, the event will be NACK'd to EventStoreDB.
* ContinueOnError: this is the exact oposite. An event will always be ACK'ed to EventStoreDB, because exceptions are logged and then swallowed.
* ContinueUntilMaxErrors: a number of errors are tolerable. The event will only be NACK'ed when the configured threshold is surpassed. If not, the event will be ACK'ed.
* ContinueUntilMaxFailureRate: same as ContinueUntilMaxErrors but the threshold is expressed as a percentage of the whole batch, rather than a fixed number.